### PR TITLE
Use wnameless/oracle-xe-11g-r2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wnameless/oracle-xe-11g:latest
+FROM wnameless/oracle-xe-11g-r2:latest
 ENV ORACLE_ALLOW_REMOTE true
 
 ADD root /

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ An Oracle XE instance configured for Moodle development based on [wnameless/dock
 ```bash
 docker run --name db0 -p 1521:1521 moodlehq/moodle-db-oracle
 ```
-
 # Bulding locally
 
 Since this image can't be pulled from Docker repo at the moment
@@ -16,8 +15,6 @@ Since this image can't be pulled from Docker repo at the moment
 to build it for local usage:
 
 ```bash
-> git clone git@github.com:wnameless/docker-oracle-xe-11g.git
-> docker build ./docker-oracle-xe-11g --tag wnameless/oracle-xe-11g
 > git clone git@github.com:moodlehq/moodle-db-oracle.git
 > docker build ./moodle-db-oracle --tag moodlehq/moodle-db-oracle
 ```


### PR DESCRIPTION
This updated image has been re-listed on Dockerhub in 09/19 following
author's communication with Oracle (see https://github.com/wnameless/docker-oracle-xe-11g for details). Not 100% sure this means that moodlehq/moodle-db-oracle can be re-published as well, but at least for local build it is enough to use this repo clone only.