### PR TITLE
Make Oracle 11g database ready output compatible with Oracle 21c

### DIFF
--- a/root/docker-entrypoint-initdb.d/01-moodle-user.sql
+++ b/root/docker-entrypoint-initdb.d/01-moodle-user.sql
@@ -16,3 +16,6 @@ ALTER DATABASE DATAFILE '/u01/app/oracle/oradata/XE/system.dbf' AUTOEXTEND ON MA
 -- Restart for the process change above to take effect.
 SHUTDOWN IMMEDIATE;
 STARTUP;
+
+-- To help detect when we are done in a 11/21 compatible way
+PROMPT DATABASE IS READY TO USE!


### PR DESCRIPTION
Till now, in various places we are using the "Database opened."
output to determine when the Oracle database is up and accepting
connections. We use that, for example, in moodle-docker:

https://github.com/moodlehq/moodle-docker/blob/master/bin/moodle-docker-wait-for-db#L17

But, the init scripts with Oracle 21c are more complex and require
to restart the database once more, so that strings isn't a good
candidate any more, because the first start is detected and the
wait script returns too early.

So, instead, what we are doing here is to ensure that the Oracle 11g
version does add "DATABASE IS READY TO USE!" at the end of the
init, because that exact string is also output by the 21c version.

That way we have a consistent string to be be checked no matter the
version of the Oracle database.